### PR TITLE
turbolinks周りのバグを修正

### DIFF
--- a/app/assets/javascripts/ragistration.js
+++ b/app/assets/javascripts/ragistration.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load',function(){
   var stack1 = [];
   var stack2 = [];
   var stack3 = [];

--- a/app/assets/javascripts/topbar.js
+++ b/app/assets/javascripts/topbar.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load',function(){
   over_flg = false;
   $(".dropdown-toggle").on("click",function(e){
     e.preventDefault();

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,7 +2,7 @@
   .container.container--signin
     %ul.nav--global-actions
       %li.global-nav-home
-        = link_to root_path, data: { turbolinks: false } do
+        = link_to root_path do
           %i.fa.fa-twitter
 .page-outer.page-outer
   - if alert == "Invalid Email or password."

--- a/app/views/layouts/_topbar.html.haml
+++ b/app/views/layouts/_topbar.html.haml
@@ -3,7 +3,7 @@
     %i.fa.fa-twitter.center
     %ul.nav--global-actions
       %li#global-nav-home
-        = link_to root_path, data: { turbolinks: false } , class: :active do
+        = link_to root_path, class: :active do
           %i.fa.fa-home
           %span.text ホーム
     %ul.nav--right-actions.pull-right


### PR DESCRIPTION
Javascriptが正しく動作しなかった問題を、
jsファイル中の発火処理の記述を修正することで対応した。
これまでHTML上でturbolinksを無効にしたリンクを貼っていた部分は記述を削除した。